### PR TITLE
Use Conda aware CMake version to massively simplify CMakeLists template

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -13,7 +13,7 @@ dependencies:
   - joblib
   - toml
   - pip
-  - cmake=3.16
+  - cmake=3.20
   - ninja
   - pip:
     - clang==10.0.1

--- a/templates/CMakeLists.j2
+++ b/templates/CMakeLists.j2
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.16 )
+cmake_minimum_required( VERSION 3.20 )
 project( {{ name }}
          LANGUAGES CXX )
 

--- a/templates/CMakeLists.j2
+++ b/templates/CMakeLists.j2
@@ -4,25 +4,10 @@ project( {{ name }}
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR} )
 
-if(WIN32)
-  set( PYTHON_EXECUTABLE "$ENV{CONDA_PREFIX}/python.exe" )
-  add_compile_definitions( _hypot=hypot _AMD64_ _WINDOWS)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import version_info as vi; print(f'{vi.major}{vi.minor}')"
-                  OUTPUT_VARIABLE PYTHON_VER )
-  string(STRIP ${PYTHON_VER} PYTHON_VER)
-  set( PYTHON_LIBRARY $ENV{CONDA_PREFIX}/libs/python${PYTHON_VER}.lib )
-else()
-  set( PYTHON_EXECUTABLE "$ENV{CONDA_PREFIX}/bin/python" )
-endif()
-
+find_package( Python COMPONENTS Interpreter Development REQUIRED )
 find_package( pybind11 REQUIRED )
 find_package( OpenCascade REQUIRED COMPONENTS OPENCASCADE )
 find_package( VTK 9.0 REQUIRED COMPONENTS WrappingPythonCore RenderingCore CommonDataModel CommonExecutionModel)
-
-#clang-cl related workaround
-if(WIN32)
-  set( PYTHON_LIBRARY $ENV{CONDA_PREFIX}/libs/python${PYTHON_VER}.lib )
-endif()
 
 include_directories( ${PROJECT_SOURCE_DIR} )
 file( GLOB CPP_FILES ${PROJECT_SOURCE_DIR}/*.cpp )


### PR DESCRIPTION
Switching to a still old but newer CMake version allows to remove Conda related workarounds for all platforms which should result in more readable and maintainable CMakeLists.

PR consists of two commits:
- Switching to to CMake 3.20 which is still an old stable version.
- Replacing Conda related workarounds with a simple proper way to find Python components which is also a recommended approach specified in **pybind11** documentation: https://pybind11.readthedocs.io/en/stable/compiling.html#findpython-mode

It *should* pass your current CI/CD pipeline without a problem.