### PR TITLE
Fix a bug in writes to the BytesIO C++ wrapper

### DIFF
--- a/pystreambuf.h
+++ b/pystreambuf.h
@@ -266,8 +266,8 @@ class streambuf : public std::basic_streambuf<char>
       py::bytes chunk(pbase(), n_written);
       py_write(chunk);
       if (!traits_type::eq_int_type(c, traits_type::eof())) {
-        char cs[2] = {traits_type::to_char_type(c)};
-        py_write(py::bytes(cs));
+        char cs = traits_type::to_char_type(c);
+        py_write(py::bytes(&cs, 1));
         n_written++;
       }
       if (n_written) {


### PR DESCRIPTION
'\0' bytes are currently being dropped due to being misinterpreted as string terminators.
Related to #47.

I was making use of your updated version of pystreambuf.h (thanks!) in https://github.com/valgur/ncompress and noticed a discrepancy between the C++ and Python outputs.