### PR TITLE
remove BOM

### DIFF
--- a/opencascade/BRepExtrema_ProximityValueTool.hxx
+++ b/opencascade/BRepExtrema_ProximityValueTool.hxx
@@ -1,4 +1,4 @@
-﻿// Created on: 2022-08-08
+// Created on: 2022-08-08
 // Created by: Kseniya NOSULKO
 // Copyright (c) 2022 OPEN CASCADE SAS
 //


### PR DESCRIPTION
The file `opencascade/BRepExtrema_ProximityValueTool.hxx` had an UTF-8 BOM at the start. This causes problems, esp. if the file is concatenated to something else when postprocessing.

`python3 -m bindgen …` reports this:
```
38%|████████████████▍                          | 120/314 [17:29<26:20,  8.15s/it][W 240105 09:03:08 translation_unit:47] ./opencascade/BRepExtrema_ProximityValueTool.hxx
[W 240105 09:03:08 translation_unit:48] dummy.cxx:12:1: warning: identifier contains Unicode character <U+FEFF> that is invisible in some environments [-Wunicode-zero-width]
[W 240105 09:03:08 translation_unit:48] dummy.cxx:12:1: error: unknown type name '﻿'
```