### PR TITLE
build: run dump_symbols in CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ execute_process(
     ${Python_EXECUTABLE}
     dump_symbols.py
     "${occt_libs}"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
 
 


### PR DESCRIPTION
Dump symbols should be run within the `CMAKE_SOURCE_DIR`. If cmake tries to run it with a different working directory it fails to find the script and generates output in the wrong place.