### PR TITLE
fix CMake not finding MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package( VTK REQUIRED
     CommonDataModel
     CommonExecutionModel
     freetype
+  OPTIONAL_COMPONENTS
     mpi
 )
 message(STATUS "VTK ${VTK_VERSION} found")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package( VTK REQUIRED
     CommonDataModel
     CommonExecutionModel
     freetype
+    mpi
 )
 message(STATUS "VTK ${VTK_VERSION} found")
 find_package( RapidJSON REQUIRED )


### PR DESCRIPTION
Building OCP 7.8.1.2 on Arch Linux against vtk 9.5.0 currently fails in the CMake Configuration stage:

```
CMake Error at /usr/lib/cmake/vtk/VTK-targets.cmake:1897 (set_target_properties):
  The link interface of target "VTK::mpi" contains:

    MPI::MPI_C

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /usr/lib/cmake/vtk/vtk-config.cmake:147 (include)
  CMakeLists.txt:8 (find_package)
```

This patch adds `mpi` to the VTK components to search for, resolving this issue.