### PR TITLE
Migration from Azure to Github Actions

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -6,6 +6,7 @@ on:
     tags: [ '*' ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   Linux:

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -1,0 +1,40 @@
+name: Build Bindings
+
+on:
+  push:
+    branches: [ master ]
+    tags: [ '*' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  Linux:
+    uses: ./.github/workflows/build-job.yml
+    with:
+      name: Linux
+      runner_generate: ubuntu-22.04
+      runner_compile: ubuntu-22.04
+      platform: Linux
+    secrets:
+      ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+
+  Windows:
+    uses: ./.github/workflows/build-job.yml
+    with:
+      name: Windows
+      # Note: As per your Azure setup, Windows generation runs on Linux first
+      runner_generate: ubuntu-22.04
+      runner_compile: windows-latest
+      platform: Windows
+    secrets:
+      ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+
+  OSX:
+    uses: ./.github/workflows/build-job.yml
+    with:
+      name: OSX
+      runner_generate: macos-15-intel # Using 13 for x86_64 compatibility or latest as needed
+      runner_compile: macos-15-intel
+      platform: OSX
+    secrets:
+      ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -50,12 +50,12 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           micromamba-version: '1.5.8-0'
-          environment-file: environment.devenv.yml
+          # REMOVE: environment-file: environment.devenv.yml
           environment-name: cpp-py-bindgen
           cache-environment: true
-          # We force a specific python version for the env creation as per your Azure setup
+          # Create a minimal environment with mamba-devenv
           create-args: >-
-            python=3.12
+            python=3.12 mamba-devenv
 
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
@@ -159,10 +159,11 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
         with:
           micromamba-version: '1.5.8-0'
-          environment-file: environment.devenv.yml
+          # REMOVE: environment-file: environment.devenv.yml
           environment-name: cpp-py-bindgen
+          # Create a minimal environment with mamba-devenv
           create-args: >-
-            python=${{ env.PYTHON_VERSION }}
+            python=${{ env.PYTHON_VERSION }} mamba-devenv
 
       - name: Prepare conda environment
         shell: bash -l {0}

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -60,7 +60,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CONDA_DEVENV_ENV_MANAGER=mamba
-          mamba devenv -f environment.devenv.yml
+          mamba-devenv -f environment.devenv.yml
 
       - name: Read output dir
         id: conf

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -119,6 +119,7 @@ jobs:
           key: ${{ steps.cache-ocp-src-restore.outputs.cache-primary-key }}
 
       - name: Copy pkl output
+        if: steps.cache-ocp-src-restore.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           mkdir -p ${{ steps.conf.outputs.OUTPUT }}_pkl
@@ -126,12 +127,14 @@ jobs:
 
       # --- Artifact Upload ---
       - name: Upload Sources
+        # if: steps.cache-ocp-src-restore.outputs.cache-hit != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: OCP_src_${{ inputs.platform }}
           path: ${{ steps.conf.outputs.OUTPUT }}
 
       - name: Upload Pickles
+        if: steps.cache-ocp-src-restore.outputs.cache-hit != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: OCP_pkl_${{ inputs.platform }}
@@ -161,6 +164,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      # rely on source artifact??
+      # - name: Restore OCP_src cache
+      #   id: cache-ocp-src-restore
+      #   uses: actions/cache/restore@v4
+      #   with:
+      #     path: ${{ steps.conf.outputs.OUTPUT }}
+      #     key: OCP-src-${{ inputs.platform }}-
 
       # --- Download Artifacts ---
       - name: Download Source Artifact
@@ -201,6 +212,7 @@ jobs:
         if: contains(inputs.runner_compile, 'ubuntu')
         shell: bash -l {0}
         run: |
+          ls -alR
           micromamba activate cpp-py-bindgen
           cmake -B build -S "../${OCP_src}" -G Ninja -DCMAKE_BUILD_TYPE=Release
           cmake --build build -j 2 -- -k 0
@@ -211,6 +223,7 @@ jobs:
         if: contains(inputs.runner_compile, 'mac')
         shell: bash -l {0}
         run: |
+          ls -alR
           micromamba activate cpp-py-bindgen
           cmake -B build -S "../${OCP_src}" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_SYSROOT=/opt/MacOSX10.15.sdk/
           cmake --build build -j 2 -- -k 0
@@ -221,6 +234,7 @@ jobs:
         if: contains(inputs.runner_compile, 'windows')
         shell: powershell
         run: |
+          Get-ChildItem -Force -Recurse
           # Note: PowerShell interpolation of env vars is different
           micromamba run -n cpp-py-bindgen cmake -B build -S "../$env:OCP_src" -G Ninja -DCMAKE_BUILD_TYPE=Release -DPython3_FIND_STRATEGY=LOCATION -DPython3_ROOT_DIR=$env:CONDA_PREFIX -DCMAKE_LINKER=lld-link.exe
           micromamba run -n cpp-py-bindgen cmake --build build -j 1 -- -v -k 0

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -251,9 +251,9 @@ jobs:
         run: |
           micromamba activate cpp-py-bindgen
           cd build
-          python -m pybind11_stubgen OCP -o . --root-suffix stubs
-          cp -r "../../${OCP_src}" ../upload
-          mv OCPstubs OCP-stubs
+          python -m pybind11_stubgen -o . OCP
+          rm -rf OCP-stubs/setup.py OCP-stubs/__pycache__ OCP-stubs/MANIFEST.in
+          cp -r "../../$(OCP_src)" ../upload
           cp -r OCP-stubs ../upload/
 
       - name: Upload Stubs Artifacts

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -50,11 +50,11 @@ jobs:
       - uses: mamba-org/setup-micromamba@v2
         with:
           # REMOVE: environment-file: environment.devenv.yml
-          environment-name: mamba-devenv
+          # environment-name: mamba-devenv
           # cache-environment: true
           # Create a minimal environment with mamba-devenv
           create-args: >-
-            python=3.12
+            -c conda-forge python=3.12 conda-devenv
 
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
@@ -159,10 +159,10 @@ jobs:
         with:
           # micromamba-version: '1.5.8-0'
           # REMOVE: environment-file: environment.devenv.yml
-          environment-name: mamba-devenv
+          # environment-name: mamba-devenv
           # Create a minimal environment with mamba-devenv
           create-args: >-
-            python=${{ env.PYTHON_VERSION }}
+            -c conda-forge python=${{ env.PYTHON_VERSION }} conda-devenv
 
       - name: Prepare conda environment
         shell: bash -l {0}

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -60,6 +60,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export CONDA_DEVENV_ENV_MANAGER=mamba
+          mamba create -n cpp-py-bindgen
           mamba-devenv -f environment.devenv.yml
 
       - name: Read output dir

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ steps.conf.outputs.OUTPUT }}
-          key: ${{ steps.cache-ocp-src-save.outputs.cache-primary-key }}
+          key: ${{ steps.cache-ocp-src-restore.outputs.cache-primary-key }}
 
       - name: Copy pkl output
         shell: bash -l {0}

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -178,7 +178,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: OCP_src_${{ inputs.platform }}
-          path: ..
+          path: ../${{ env.OCP_src }}
 
       # --- Mac SDK Hack (Compile Phase) ---
       - name: SDK install (Mac)
@@ -234,7 +234,7 @@ jobs:
         if: contains(inputs.runner_compile, 'windows')
         shell: powershell
         run: |
-          Get-ChildItem -Force -Recurse
+          Get-ChildItem -Force -Recurse ../
           # Note: PowerShell interpolation of env vars is different
           micromamba run -n cpp-py-bindgen cmake -B build -S "../$env:OCP_src" -G Ninja -DCMAKE_BUILD_TYPE=Release -DPython3_FIND_STRATEGY=LOCATION -DPython3_ROOT_DIR=$env:CONDA_PREFIX -DCMAKE_LINKER=lld-link.exe
           micromamba run -n cpp-py-bindgen cmake --build build -j 1 -- -v -k 0

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -55,7 +55,7 @@ jobs:
           cache-environment: true
           # Create a minimal environment with mamba-devenv
           create-args: >-
-            python=3.12 mamba-devenv
+            -c conda-forge python=3.12 mamba-devenv
 
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
@@ -163,7 +163,7 @@ jobs:
           environment-name: cpp-py-bindgen
           # Create a minimal environment with mamba-devenv
           create-args: >-
-            python=${{ env.PYTHON_VERSION }} mamba-devenv
+            -c conda-forge python=${{ env.PYTHON_VERSION }} mamba-devenv
 
       - name: Prepare conda environment
         shell: bash -l {0}

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
-        run: micromamba run mamba-devenv -f environment.devenv.yml
+        run: mamba-devenv -f environment.devenv.yml
 
       - name: Read output dir
         id: conf
@@ -166,7 +166,7 @@ jobs:
 
       - name: Prepare conda environment
         shell: bash -l {0}
-        run: micromamba run mamba-devenv -f environment.devenv.yml
+        run: mamba-devenv -f environment.devenv.yml
 
       # --- Compilation ---
       

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
         run: |
-          mamba devenv -e mamba
-          mamba devenv -f environment.devenv.yml
+          micromamba devenv -e mamba
+          micromamba devenv -f environment.devenv.yml
 
       - name: Read output dir
         id: conf

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -212,7 +212,7 @@ jobs:
         if: contains(inputs.runner_compile, 'ubuntu')
         shell: bash -l {0}
         run: |
-          ls -alR
+          ls -alR ../
           micromamba activate cpp-py-bindgen
           cmake -B build -S "../${OCP_src}" -G Ninja -DCMAKE_BUILD_TYPE=Release
           cmake --build build -j 2 -- -k 0

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@v2
         with:
           # REMOVE: environment-file: environment.devenv.yml
-          # environment-name: cpp-py-bindgen
+          environment-name: mamba-devenv
           # cache-environment: true
           # Create a minimal environment with mamba-devenv
           create-args: >-
@@ -159,7 +159,7 @@ jobs:
         with:
           # micromamba-version: '1.5.8-0'
           # REMOVE: environment-file: environment.devenv.yml
-          # environment-name: cpp-py-bindgen
+          environment-name: mamba-devenv
           # Create a minimal environment with mamba-devenv
           create-args: >-
             python=${{ env.PYTHON_VERSION }}

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -35,13 +35,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Restore OCP_src cache
-        id: cache-ocp-src-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ steps.conf.outputs.OUTPUT }}
-          key: OCP-src-${{ inputs.platform }}-
-
       # --- Mac SDK Hack ---
       - name: SDK install and symlink (Mac)
         if: contains(inputs.runner_generate, 'mac')
@@ -77,6 +70,13 @@ jobs:
           micromamba activate cpp-py-bindgen
           OUTPUT=`python -c'import toml; print(toml.load("ocp.toml")["output_folder"])'`
           echo "OUTPUT=$OUTPUT" >> $GITHUB_OUTPUT
+
+      - name: Restore OCP_src cache
+        id: cache-ocp-src-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.conf.outputs.OUTPUT }}
+          key: OCP-src-${{ inputs.platform }}-
 
       # --- Generation Logic ---
       

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -35,6 +35,13 @@ jobs:
         with:
           submodules: true
 
+      - name: Restore OCP_src cache
+        id: cache-ocp-src-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.conf.outputs.OUTPUT }}
+          key: OCP-src-${{ inputs.platform }}-
+
       # --- Mac SDK Hack ---
       - name: SDK install and symlink (Mac)
         if: contains(inputs.runner_generate, 'mac')
@@ -75,10 +82,10 @@ jobs:
       
       # Windows Special Case (Running on Linux targeting Windows)
       - name: Generate (Windows on Linux)
-        if: inputs.platform == 'Windows'
+        if: inputs.platform == 'Windows' && steps.cache-ocp-src-restore.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
-          micromamba create --yes --platform win-64 --no-deps --prefix ./occt occt=7.9.0
+          micromamba create --yes --platform win-64 --no-deps --prefix ./occt occt=7.9.2
           micromamba activate cpp-py-bindgen
           cmake -S . -B . -G Ninja \
             -DPython_ROOT_DIR=$CONDA_PREFIX \
@@ -92,7 +99,7 @@ jobs:
 
       # Standard Case (Linux/Mac)
       - name: Generate (Standard)
-        if: inputs.platform != 'Windows'
+        if: inputs.platform != 'Windows' && steps.cache-ocp-src-restore.outputs.cache-hit != 'true'
         shell: bash -l {0}
         run: |
           micromamba activate cpp-py-bindgen
@@ -103,6 +110,13 @@ jobs:
             -DPython3_FIND_VIRTUALENV=ONLY
           cmake --build .
           ls -lRht
+
+      - name: Cache OCP_src
+        id: cache-ocp-src-save
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.conf.outputs.OUTPUT }}
+          key: ${{ steps.cache-ocp-src-save.outputs.cache-primary-key }}
 
       - name: Copy pkl output
         shell: bash -l {0}
@@ -116,14 +130,12 @@ jobs:
         with:
           name: OCP_src_${{ inputs.platform }}
           path: ${{ steps.conf.outputs.OUTPUT }}
-          retention-days: 1
 
       - name: Upload Pickles
         uses: actions/upload-artifact@v4
         with:
           name: OCP_pkl_${{ inputs.platform }}
           path: ${{ steps.conf.outputs.OUTPUT }}_pkl
-          retention-days: 1
 
   # -----------------------------------------------------------------------------
   # PHASE 2: Compile (Matrix)
@@ -132,7 +144,7 @@ jobs:
     needs: generate
     name: Compile ${{ inputs.name }} (3.${{ matrix.py_min }})
     runs-on: ${{ inputs.runner_compile }}
-    timeout-minutes: 360
+    # timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@v2
         with:
           # REMOVE: environment-file: environment.devenv.yml
-          # environment-name: mamba-devenv
+          environment-name: placeholder
           # cache-environment: true
           # Create a minimal environment with mamba-devenv
           create-args: >-
@@ -159,7 +159,7 @@ jobs:
         with:
           # micromamba-version: '1.5.8-0'
           # REMOVE: environment-file: environment.devenv.yml
-          # environment-name: mamba-devenv
+          environment-name: placeholder
           # Create a minimal environment with mamba-devenv
           create-args: >-
             -c conda-forge python=${{ env.PYTHON_VERSION }} conda-devenv

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -165,12 +165,13 @@ jobs:
           environment-name: placeholder
           # Create a minimal environment with mamba-devenv
           create-args: >-
-            -c conda-forge python=${{ env.PYTHON_VERSION }} conda-devenv
+            -c conda-forge python=${{ env.PYTHON_VERSION }} conda-devenv mamba
 
       - name: Prepare conda environment
         shell: bash -l {0}
         run: |
-          micromamba activate placeholder
+          export CONDA_DEVENV_ENV_MANAGER=mamba
+          mamba create -n cpp-py-bindgen
           mamba-devenv -f environment.devenv.yml
 
       # --- Compilation ---

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
         run: |
-          micromamba activate placeholder
-          mamba-devenv -f environment.devenv.yml
+          mamba devenv -e mamba
+          mamba devenv -f environment.devenv.yml
 
       - name: Read output dir
         id: conf

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -212,7 +212,6 @@ jobs:
         if: contains(inputs.runner_compile, 'ubuntu')
         shell: bash -l {0}
         run: |
-          ls -alR ../
           micromamba activate cpp-py-bindgen
           cmake -B build -S "../${OCP_src}" -G Ninja -DCMAKE_BUILD_TYPE=Release
           cmake --build build -j 2 -- -k 0
@@ -223,7 +222,6 @@ jobs:
         if: contains(inputs.runner_compile, 'mac')
         shell: bash -l {0}
         run: |
-          ls -alR
           micromamba activate cpp-py-bindgen
           cmake -B build -S "../${OCP_src}" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_SYSROOT=/opt/MacOSX10.15.sdk/
           cmake --build build -j 2 -- -k 0
@@ -234,13 +232,18 @@ jobs:
         if: contains(inputs.runner_compile, 'windows')
         shell: powershell
         run: |
-          Get-ChildItem -Force -Recurse ../
           # Note: PowerShell interpolation of env vars is different
           micromamba run -n cpp-py-bindgen cmake -B build -S "../$env:OCP_src" -G Ninja -DCMAKE_BUILD_TYPE=Release -DPython3_FIND_STRATEGY=LOCATION -DPython3_ROOT_DIR=$env:CONDA_PREFIX -DCMAKE_LINKER=lld-link.exe
           micromamba run -n cpp-py-bindgen cmake --build build -j 1 -- -v -k 0
           micromamba run -n cpp-py-bindgen cmake -E rm -rf build\CMakeFiles
         env:
           CXX: "cl.exe"
+
+      - name: Upload Compilation Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: OCP_${{ inputs.platform }}_py3${{ matrix.py_min }}
+          path: build
 
       # --- Stubs & Test ---
       - name: Generate stubs
@@ -252,6 +255,12 @@ jobs:
           cp -r "../../${OCP_src}" ../upload
           mv OCPstubs OCP-stubs
           cp -r OCP-stubs ../upload/
+
+      - name: Upload Stubs Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: OCP_src_stubs_${{ inputs.platform }}_py3${{ matrix.py_min }}
+          path: upload
 
       - name: Test Import
         shell: bash -l {0}
@@ -266,7 +275,6 @@ jobs:
           fi
 
       # --- Conda Packaging ---
-      # Combined the PR and Push logic into one step using dynamic flags
       - name: Build Conda Package
         shell: bash -l {0}
         env:
@@ -285,9 +293,3 @@ jobs:
             echo "Building and Uploading..."
             conda build --token $TOKEN --user cadquery --label dev -c conda-forge --override-channels conda
           fi
-          
-      - name: Upload Compilation Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: OCP_${{ inputs.platform }}_py3${{ matrix.py_min }}
-          path: build

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -88,6 +88,7 @@ jobs:
             -DOCCT_LIB_DIR=./occt/Library/bin/ \
             -DPLATFORM=Windows
           cmake --build . -- -v
+          ls -lRht
 
       # Standard Case (Linux/Mac)
       - name: Generate (Standard)
@@ -101,6 +102,13 @@ jobs:
             -DPython_FIND_VIRTUALENV=ONLY \
             -DPython3_FIND_VIRTUALENV=ONLY
           cmake --build .
+          ls -lRht
+
+      - name: Copy pkl output
+        shell: bash -l {0}
+        run: |
+          mkdir -p ${{ steps.conf.outputs.OUTPUT }}_pkl
+          cp *.pkl ${{ steps.conf.outputs.OUTPUT }}_pkl/
 
       # --- Artifact Upload ---
       - name: Upload Sources
@@ -147,7 +155,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: OCP_src_${{ inputs.platform }}
-          path: ${{ env.OCP_src }}
+          path: ..
 
       # --- Mac SDK Hack (Compile Phase) ---
       - name: SDK install (Mac)

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -1,0 +1,253 @@
+name: Build Bindings Logic
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+      runner_generate:
+        required: true
+        type: string
+      runner_compile:
+        required: true
+        type: string
+      platform:
+        required: true
+        type: string
+    secrets:
+      ANACONDA_TOKEN:
+        required: false
+
+jobs:
+  # -----------------------------------------------------------------------------
+  # PHASE 1: Generate Bindings (Python wrapper generation)
+  # -----------------------------------------------------------------------------
+  generate:
+    name: Generate ${{ inputs.name }}
+    runs-on: ${{ inputs.runner_generate }}
+    timeout-minutes: 360
+    outputs:
+      output_dir: ${{ steps.conf.outputs.OUTPUT }}
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # --- Mac SDK Hack ---
+      - name: SDK install and symlink (Mac)
+        if: contains(inputs.runner_generate, 'mac')
+        run: |
+          curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz
+          sudo mkdir -p /opt
+          sudo tar -xf MacOSX11.3.sdk.tar.xz -C /opt
+          sudo mkdir -p /opt/usr/local/
+          sudo ln -s /opt/MacOSX11.3.sdk/usr/include /opt/usr/local/include
+          sudo ln -s /opt/MacOSX11.3.sdk/System/Library/Frameworks/OpenGL.framework/Headers /usr/local/include/OpenGL
+
+      # --- Setup Environment ---
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: '1.5.8-0'
+          environment-file: environment.devenv.yml
+          environment-name: cpp-py-bindgen
+          cache-environment: true
+          # We force a specific python version for the env creation as per your Azure setup
+          create-args: >-
+            python=3.12
+
+      - name: Prepare conda environment (mamba-devenv)
+        shell: bash -l {0}
+        run: micromamba run -n cpp-py-bindgen mamba-devenv -f environment.devenv.yml
+
+      - name: Read output dir
+        id: conf
+        shell: bash -l {0}
+        run: |
+          micromamba activate cpp-py-bindgen
+          OUTPUT=`python -c'import toml; print(toml.load("ocp.toml")["output_folder"])'`
+          echo "OUTPUT=$OUTPUT" >> $GITHUB_OUTPUT
+
+      # --- Generation Logic ---
+      
+      # Windows Special Case (Running on Linux targeting Windows)
+      - name: Generate (Windows on Linux)
+        if: inputs.platform == 'Windows'
+        shell: bash -l {0}
+        run: |
+          micromamba create --yes --platform win-64 --no-deps --prefix ./occt occt=7.9.0
+          micromamba activate cpp-py-bindgen
+          cmake -S . -B . -G Ninja \
+            -DPython_ROOT_DIR=$CONDA_PREFIX \
+            -DPython3_ROOT_DIR=$CONDA_PREFIX \
+            -DPython_FIND_VIRTUALENV=ONLY \
+            -DPython3_FIND_VIRTUALENV=ONLY \
+            -DOCCT_LIB_DIR=./occt/Library/bin/ \
+            -DPLATFORM=Windows
+          cmake --build . -- -v
+
+      # Standard Case (Linux/Mac)
+      - name: Generate (Standard)
+        if: inputs.platform != 'Windows'
+        shell: bash -l {0}
+        run: |
+          micromamba activate cpp-py-bindgen
+          cmake -S . -B . -G Ninja \
+            -DPython_ROOT_DIR=$CONDA_PREFIX \
+            -DPython3_ROOT_DIR=$CONDA_PREFIX \
+            -DPython_FIND_VIRTUALENV=ONLY \
+            -DPython3_FIND_VIRTUALENV=ONLY
+          cmake --build .
+
+      # --- Artifact Upload ---
+      - name: Upload Sources
+        uses: actions/upload-artifact@v4
+        with:
+          name: OCP_src_${{ inputs.platform }}
+          path: ${{ steps.conf.outputs.OUTPUT }}
+          retention-days: 1
+
+      - name: Upload Pickles
+        uses: actions/upload-artifact@v4
+        with:
+          name: OCP_pkl_${{ inputs.platform }}
+          path: ${{ steps.conf.outputs.OUTPUT }}_pkl
+          retention-days: 1
+
+  # -----------------------------------------------------------------------------
+  # PHASE 2: Compile (Matrix)
+  # -----------------------------------------------------------------------------
+  compile:
+    needs: generate
+    name: Compile ${{ inputs.name }} (3.${{ matrix.py_min }})
+    runs-on: ${{ inputs.runner_compile }}
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        py_min: [10, 11, 12, 13]
+    
+    env:
+      OCP_src: OCP_src_${{ inputs.platform }}
+      n_cores: 2
+      PYTHON_VERSION: 3.${{ matrix.py_min }}
+      STAGE: "compile"
+      ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # --- Download Artifacts ---
+      - name: Download Source Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: OCP_src_${{ inputs.platform }}
+          path: ${{ env.OCP_src }}
+
+      # --- Mac SDK Hack (Compile Phase) ---
+      - name: SDK install (Mac)
+        if: contains(inputs.runner_compile, 'mac')
+        run: |
+          curl -L -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX10.15.sdk.tar.xz
+          sudo mkdir -p /opt
+          sudo tar -xf MacOSX10.15.sdk.tar.xz -C /opt
+
+      # --- Setup Environment ---
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: '1.5.8-0'
+          environment-file: environment.devenv.yml
+          environment-name: cpp-py-bindgen
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
+
+      - name: Prepare conda environment
+        shell: bash -l {0}
+        run: micromamba run -n cpp-py-bindgen mamba-devenv -f environment.devenv.yml
+
+      # --- Compilation ---
+      
+      # Ubuntu Compile
+      - name: Compile (Ubuntu)
+        if: contains(inputs.runner_compile, 'ubuntu')
+        shell: bash -l {0}
+        run: |
+          micromamba activate cpp-py-bindgen
+          cmake -B build -S "../${OCP_src}" -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -j 2 -- -k 0
+          rm -rf build/CMakeFiles
+
+      # Mac Compile
+      - name: Compile (Mac)
+        if: contains(inputs.runner_compile, 'mac')
+        shell: bash -l {0}
+        run: |
+          micromamba activate cpp-py-bindgen
+          cmake -B build -S "../${OCP_src}" -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_SYSROOT=/opt/MacOSX10.15.sdk/
+          cmake --build build -j 2 -- -k 0
+          rm -rf build/CMakeFiles
+
+      # Windows Compile
+      - name: Compile (Windows)
+        if: contains(inputs.runner_compile, 'windows')
+        shell: powershell
+        run: |
+          # Note: PowerShell interpolation of env vars is different
+          micromamba run -n cpp-py-bindgen cmake -B build -S "../$env:OCP_src" -G Ninja -DCMAKE_BUILD_TYPE=Release -DPython3_FIND_STRATEGY=LOCATION -DPython3_ROOT_DIR=$env:CONDA_PREFIX -DCMAKE_LINKER=lld-link.exe
+          micromamba run -n cpp-py-bindgen cmake --build build -j 1 -- -v -k 0
+          micromamba run -n cpp-py-bindgen cmake -E rm -rf build\CMakeFiles
+        env:
+          CXX: "cl.exe"
+
+      # --- Stubs & Test ---
+      - name: Generate stubs
+        shell: bash -l {0}
+        run: |
+          micromamba activate cpp-py-bindgen
+          cd build
+          python -m pybind11_stubgen OCP -o . --root-suffix stubs
+          cp -r "../../${OCP_src}" ../upload
+          mv OCPstubs OCP-stubs
+          cp -r OCP-stubs ../upload/
+
+      - name: Test Import
+        shell: bash -l {0}
+        run: |
+          micromamba activate cpp-py-bindgen
+          cd build
+          # LD_DEBUG is linux specific, keeping it safe for others
+          if [[ "${{ inputs.platform }}" == "Linux" ]]; then
+             LD_DEBUG=libs python -c"import OCP"
+          else
+             python -c"import OCP"
+          fi
+
+      # --- Conda Packaging ---
+      # Combined the PR and Push logic into one step using dynamic flags
+      - name: Build Conda Package
+        shell: bash -l {0}
+        env:
+          BUILD_STRING: "1"
+          TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+        run: |
+          # Install build tools in a fresh env
+          micromamba create -n build -y -c conda-forge python=3.11 liblief=0.14.1 conda-build anaconda-client
+          micromamba activate build
+          
+          # Determine flags based on event
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Building for PR..."
+            conda build -c conda-forge --override-channels conda
+          else
+            echo "Building and Uploading..."
+            conda build --token $TOKEN --user cadquery --label dev -c conda-forge --override-channels conda
+          fi
+          
+      - name: Upload Compilation Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: OCP_${{ inputs.platform }}_py3${{ matrix.py_min }}
+          path: build

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
-        run: mamba-devenv -f environment.devenv.yml
+        run: |
+          micromamba activate placeholder
+          mamba-devenv -f environment.devenv.yml
 
       - name: Read output dir
         id: conf
@@ -166,7 +168,9 @@ jobs:
 
       - name: Prepare conda environment
         shell: bash -l {0}
-        run: mamba-devenv -f environment.devenv.yml
+        run: |
+          micromamba activate placeholder
+          mamba-devenv -f environment.devenv.yml
 
       # --- Compilation ---
       

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
-        run: micromamba run -n mamba-devenv -f environment.devenv.yml
+        run: micromamba run mamba-devenv -f environment.devenv.yml
 
       - name: Read output dir
         id: conf
@@ -166,7 +166,7 @@ jobs:
 
       - name: Prepare conda environment
         shell: bash -l {0}
-        run: micromamba run -n mamba-devenv -f environment.devenv.yml
+        run: micromamba run mamba-devenv -f environment.devenv.yml
 
       # --- Compilation ---
       

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -54,13 +54,13 @@ jobs:
           # cache-environment: true
           # Create a minimal environment with mamba-devenv
           create-args: >-
-            -c conda-forge python=3.12 conda-devenv
+            -c conda-forge python=3.12 conda-devenv mamba
 
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
         run: |
-          micromamba devenv -e mamba
-          micromamba devenv -f environment.devenv.yml
+          export CONDA_DEVENV_ENV_MANAGER=mamba
+          mamba devenv -f environment.devenv.yml
 
       - name: Read output dir
         id: conf

--- a/.github/workflows/build-job.yml
+++ b/.github/workflows/build-job.yml
@@ -47,19 +47,18 @@ jobs:
           sudo ln -s /opt/MacOSX11.3.sdk/System/Library/Frameworks/OpenGL.framework/Headers /usr/local/include/OpenGL
 
       # --- Setup Environment ---
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.8-0'
           # REMOVE: environment-file: environment.devenv.yml
-          environment-name: cpp-py-bindgen
-          cache-environment: true
+          # environment-name: cpp-py-bindgen
+          # cache-environment: true
           # Create a minimal environment with mamba-devenv
           create-args: >-
-            -c conda-forge python=3.12 mamba-devenv
+            python=3.12
 
       - name: Prepare conda environment (mamba-devenv)
         shell: bash -l {0}
-        run: micromamba run -n cpp-py-bindgen mamba-devenv -f environment.devenv.yml
+        run: micromamba run -n mamba-devenv -f environment.devenv.yml
 
       - name: Read output dir
         id: conf
@@ -156,18 +155,18 @@ jobs:
           sudo tar -xf MacOSX10.15.sdk.tar.xz -C /opt
 
       # --- Setup Environment ---
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          micromamba-version: '1.5.8-0'
+          # micromamba-version: '1.5.8-0'
           # REMOVE: environment-file: environment.devenv.yml
-          environment-name: cpp-py-bindgen
+          # environment-name: cpp-py-bindgen
           # Create a minimal environment with mamba-devenv
           create-args: >-
-            -c conda-forge python=${{ env.PYTHON_VERSION }} mamba-devenv
+            python=${{ env.PYTHON_VERSION }}
 
       - name: Prepare conda environment
         shell: bash -l {0}
-        run: micromamba run -n cpp-py-bindgen mamba-devenv -f environment.devenv.yml
+        run: micromamba run -n mamba-devenv -f environment.devenv.yml
 
       # --- Compilation ---
       

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pywrap"]
 	path = pywrap
-	url = https://github.com/CadQuery/pywrap.git
+	url = https://github.com/jdegenstein/pywrap.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pywrap"]
 	path = pywrap
-	url = https://github.com/jdegenstein/pywrap.git
+	url = https://github.com/CadQuery/pywrap.git


### PR DESCRIPTION
I noticed that the Azure "runs" seemed slow, so I decided to experiment with porting these "runs" to GitHub Actions. In the process of getting this working I noted that GitHub runners tend to execute somewhere around 36% faster. Absent any restrictions on runtime limits maybe this wouldn't be worth it -- but I noticed that some prior jobs simply failed because they exceeded said limits. Furthermore, being able to run additional jobs in a given day may make it easier to maintain CadQuery/OCP.

There are other benefits as well, such as direct integration of these workflows into this GitHub repository and it can possibly simplify access control and management of secrets as well. GitHub Actions also has a robust ecosystem of re-usable first and 3rd party actions that make it easier to add additional functionality to the workflows.

In the end, I was able to get all of the major steps working on GitHub actions. Creating the following artifacts:
```
OCP_src_*
OCP_*
OCP_src_stubs_*
```
Other notable details:
1. I attempted to maintain close parity in build / environment setups -- for instance, making use of micromamba.
2. Dropped connection with CadQuery/conda-packages repository due to differences in the way GitHub Actions works vs. Azure. This may be possible to restore, but I didn't investigate deeply (yet).
3. I have included a step to publish to conda, but was not able to fully test that step yet.
4. Currently caching is enabled for OCP_src_* generation, but this can be easily disabled if desired. This helped make debugging later steps in the workflow faster.
5. I kept `-j 1` on the Windows compilation step to more closely reflect the workflow on Azure.
6. OCP_src_stubs may contain additional files than it should, but I haven't checked closely. Would be easy to correct.
7. I have attempted to keep this current with CadQuery/OCP master branch, including some of the recent changes to pybind11-stubgen and CadQuery fork.

Example jdegenstein/OCP GitHub Actions run with all artifacts attached:
https://github.com/jdegenstein/OCP/actions/runs/20280362367