### PR TITLE
Add BRep_Tool.CurveOnSurface_r returning (pcurve, first, last) (#167)

### DIFF
--- a/ocp.toml
+++ b/ocp.toml
@@ -569,6 +569,14 @@ py::implicitly_convertible<std::string, TCollection_AsciiString>();"""
 
         exclude_typedefs = ["IntPolyh_ArrayOfEdges","IntPolyh_ArrayOfTriangles","IntPolyh_ArrayOfPointNormal","IntPolyh_ArrayOfSectionLines","IntPolyh","IntPolyh_ArrayOfTangentZones","IntPolyh_ArrayOfPoints"]
 
+    [Modules.BRep]
+
+        [Modules.BRep.Classes.BRep_Tool.additional_static_methods.CurveOnSurface_r]
+
+            body = "[](const TopoDS_Edge& E, const TopoDS_Face& F){ Standard_Real first, last; auto curve = BRep_Tool::CurveOnSurface(E, F, first, last); return std::make_tuple(curve, first, last); }"
+            help = "Returns (pcurve, first, last): the 2D curve of edge E on face F and its parameter range."
+            arguments = ["E", "F"]
+
     [Modules.BRepBuilderAPI]
 
         exclude_typedefs = ["BRepBuilderAPI_CellFilter","BRepBuilderAPI_BndBoxTree"]


### PR DESCRIPTION
## Summary

Fixes #167.

`BRep_Tool::CurveOnSurface` returns a non-void `Handle(Geom2d_Curve)` **and** reports the
edge's parameter range through reference arguments (`Standard_Real& First, Standard_Real& Last`).
Because `Standard_Real` maps to an immutable Python `float`, those outputs cannot be written
back to the caller, so the parameter range is unreachable from Python — which blocks the
parametric-space (UV) workflows described in the issue.

The existing call-by-reference → tuple mechanism (`is_byref` in pywrap) only triggers for
**void**-returning methods, so a non-void method like this one is missed.

## Change

A targeted, **non-breaking** workaround via the rules mechanism (as suggested in the issue
thread — "add workaround method in the binding manually or via rules"). It adds a new static
method and leaves the original `CurveOnSurface_s` binding untouched:

```toml
[Modules.BRep.Classes.BRep_Tool.additional_static_methods.CurveOnSurface_r]
body = "[](const TopoDS_Edge& E, const TopoDS_Face& F){ Standard_Real first, last; auto curve = BRep_Tool::CurveOnSurface(E, F, first, last); return std::make_tuple(curve, first, last); }"
```

Usage:

```python
from OCP.BRep import BRep_Tool
curve, first, last = BRep_Tool.CurveOnSurface_r(edge, face)
```

The `_r` suffix denotes "reference outputs returned as a tuple". Only the edge-on-face
overload is wrapped here.

## Questions for the maintainers
@adam-urbanczyk 
1. **Does this targeted approach look acceptable?** It mirrors the existing
   `additional_static_methods` precedents and changes no existing signatures.

2. **Would you prefer a more general implementation instead?** The void call-by-reference
   tuple handling could be generalized to also cover **non-void** methods whose outputs come
   back through immutable-type references (`Standard_Real`/`Standard_Integer`/`Standard_Boolean`),
   auto-generating these tuple variants — i.e. the same treatment void functions already get.
   That would be a change in **pywrap** (relaxing the `void`-only gate in `is_byref` and
   extending the byref lambda in `template_sub.j2` to prepend the return value to the tuple),
   not in this repo. Happy to open that as a separate pywrap PR if you'd rather solve it
   generally.