### PR TITLE
Fix arg.name → arg.arg_name in pywrap macros.j2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pywrap"]
 	path = pywrap
-	url = https://github.com/CadQuery/pywrap.git
+	url = https://github.com/elliejs/pywrap.git


### PR DESCRIPTION
## Summary
- Points pywrap submodule at elliejs/pywrap@499cd39 which fixes the
  `arg.name` → `arg.arg_name` bug in `macros.j2:44` (CadQuery/pywrap#63)
- `init_outputs_byref` uses `arg.name` which doesn't exist on `ArgInfo` —
  Jinja2 silently renders it as empty string, producing broken C++ like
  `_ptr; _ptr = &;` instead of `myArg_ptr; myArg_ptr = &myArg;`
- 377 broken declarations across 65 generated files, all platforms
- Temporarily points submodule URL at elliejs/pywrap so CI can resolve
  the commit; revert to CadQuery/pywrap once CadQuery/pywrap#63 merges

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>